### PR TITLE
have separate requirements for miner/validator

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -1,31 +1,73 @@
-version: '1.0'
+# Use this document to specify the minimum compute requirements.
+# This document will be used to generate a list of recommended hardware for your subnet.
+
+# This is intended to give a rough estimate of the minimum requirements
+# so that the user can make an informed decision about whether or not
+# they want to run a miner or validator on their machine.
+
+# NOTE: Specification for miners may be different from validators
+
+version: '1.0' # update this version key as needed, ideally should match your release version
 
 compute_spec:
-  cpu:
-    min_cores: 4  # Minimum number of CPU cores
-    min_speed: 2.5GHz  # Minimum speed per core
-    architecture: x86_64  # Architecture type (e.g., x86_64, arm64)
 
-  gpu:
-    required: true  # Does the application require a GPU?
-    min_vram: 8GB  # Minimum GPU VRAM
-    cuda_cores: 1024  # Minimum number of CUDA cores (if applicable)
-    min_compute_capability: 6.0  # Minimum CUDA compute capability
+  miner:
 
-  memory:
-    min_ram: 16GB  # Minimum RAM
-    min_swap: 4GB  # Minimum swap space
+    cpu:
+      min_cores: 4  # Minimum number of CPU cores
+      min_speed: 2.5GHz  # Minimum speed per core
+      architecture: x86_64  # Architecture type (e.g., x86_64, arm64)
 
-  storage:
-    min_space: 100GB  # Minimum free storage space
-    type: SSD  # Preferred storage type (e.g., SSD, HDD)
-    iops: 1000  # Minimum I/O operations per second (if applicable)
+    gpu:
+      required: true  # Does the application require a GPU?
+      min_vram: 8GB  # Minimum GPU VRAM
+      cuda_cores: 1024  # Minimum number of CUDA cores (if applicable)
+      min_compute_capability: 6.0  # Minimum CUDA compute capability
+      recommended_gpu: "NVIDIA A100" # provide a recommended GPU to purchase/rent
 
-  os:
-    name: Ubuntu  # Name of the preferred operating system(s)
-    version: ">=20.04"  # Version of the preferred operating system(s)
+    memory:
+      min_ram: 16GB  # Minimum RAM
+      min_swap: 4GB  # Minimum swap space
+      ram_type: "DDR4" # RAM type (e.g., DDR4, DDR3, etc.)
 
-network:
+    storage:
+      min_space: 100GB  # Minimum free storage space
+      type: SSD  # Preferred storage type (e.g., SSD, HDD)
+      iops: 1000  # Minimum I/O operations per second (if applicable)
+
+    os:
+      name: Ubuntu  # Name of the preferred operating system(s)
+      version: "20.04"  # Version of the preferred operating system(s)
+
+  validator:
+
+    cpu:
+      min_cores: 4  # Minimum number of CPU cores
+      min_speed: 2.5GHz  # Minimum speed per core
+      architecture: x86_64  # Architecture type (e.g., x86_64, arm64)
+
+    gpu:
+      required: true  # Does the application require a GPU?
+      min_vram: 8GB  # Minimum GPU VRAM
+      cuda_cores: 1024  # Minimum number of CUDA cores (if applicable)
+      min_compute_capability: 6.0  # Minimum CUDA compute capability
+      recommended_gpu: "NVIDIA A100" # provide a recommended GPU to purchase/rent
+
+    memory:
+      min_ram: 16GB  # Minimum RAM
+      min_swap: 4GB  # Minimum swap space
+      ram_type: "DDR4" # RAM type (e.g., DDR4, DDR3, etc.)
+
+    storage:
+      min_space: 100GB  # Minimum free storage space
+      type: SSD  # Preferred storage type (e.g., SSD, HDD)
+      iops: 1000  # Minimum I/O operations per second (if applicable)
+
+    os:
+      name: Ubuntu  # Name of the preferred operating system(s)
+      version: ">=20.04"  # Version of the preferred operating system(s)
+
+network_spec:
   bandwidth:
     download: ">=100Mbps"  # Minimum download bandwidth
     upload: ">=20Mbps"  # Minimum upload bandwidth


### PR DESCRIPTION
Divide compute requirements into miner and validator buckets.

This can be used to pull data from each subnet repo as the owner updates them and we can post this data on bittensor.com, potentially with some recommended hardware if you want to validate on a specific subset of subnets or the whole network.