### PR TITLE
Moved load_state() to the neuron.__init__

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -44,7 +44,6 @@ class Validator(BaseValidatorNeuron):
         super(Validator, self).__init__(config=config)
 
         bt.logging.info("load_state()")
-        self.load_state()
 
         # TODO(developer): Anything specific to your use case you can do here
 

--- a/template/base/neuron.py
+++ b/template/base/neuron.py
@@ -99,6 +99,8 @@ class BaseNeuron(ABC):
         )
         self.step = 0
 
+        self.load_state()
+
     @abstractmethod
     async def forward(self, synapse: bt.Synapse) -> bt.Synapse:
         ...

--- a/template/base/validator.py
+++ b/template/base/validator.py
@@ -19,6 +19,7 @@
 
 
 import copy
+import os
 import torch
 import asyncio
 import threading
@@ -338,6 +339,10 @@ class BaseValidatorNeuron(BaseNeuron):
     def load_state(self):
         """Loads the state of the validator from a file."""
         bt.logging.info("Loading validator state.")
+
+        if not os.path.exists(self.config.neuron.full_path + "/state.pt"):
+            bt.logging.warning("No saved state found")
+            return
 
         # Load the state of the validator from file.
         state = torch.load(self.config.neuron.full_path + "/state.pt")


### PR DESCRIPTION
In the current code, the template.base.validator calls self.sync during initialization which leads to the state being saved (calling self.save_state). And it happens before state being loaded in the neuron.validator initialization. Since the sync function is in the neuron code and it calls save_state there, it's logical to move load_state to neuron initialization. An alternative would be not to call sync during initialization, since it's being called the first thing in the run method.