### PR TITLE
fix base miner.py axon init params

### DIFF
--- a/template/base/miner.py
+++ b/template/base/miner.py
@@ -45,7 +45,7 @@ class BaseMinerNeuron(BaseNeuron):
             )
 
         # The axon handles request processing, allowing validators to send this miner requests.
-        self.axon = bt.axon(wallet=self.wallet, port=self.config.axon.port)
+        self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to miner axon.")


### PR DESCRIPTION
Problem:
Default example omits the axon ip and external_ip so servers that need to use specific --axon.ip and axon.external_ip configs will not work

Solution:
Pass the whole config object to the init function to ensure everything from the command line arguments is passed 

Bittensor docs ref for axon:
https://github.com/opentensor/bittensor/blob/935217242ef8b48ecf0d63f9bb0b920905c8cda8/bittensor/axon.py#L215