### PR TITLE
enhanced blacklisting feature

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -95,12 +95,23 @@ class Miner(BaseMinerNeuron):
         Otherwise, allow the request to be processed further.
         """
         # TODO(developer): Define how miners should blacklist requests.
-        if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
-            # Ignore requests from unrecognized entities.
+        uid = self.metagraph.hotkeys.index( synapse.dendrite.hotkey)
+        if not self.config.blacklist.allow_non_registered and synapse.dendrite.hotkey not in self.metagraph.hotkeys:
+            # Ignore requests from un-registered entities.
             bt.logging.trace(
-                f"Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}"
+                f"Blacklisting un-registered hotkey {synapse.dendrite.hotkey}"
             )
             return True, "Unrecognized hotkey"
+        
+        if self.config.blacklist.force_validator_permit:
+            # If the config is set to force validator permit, then we should only allow requests from validators.
+            if not self.metagraph.validator_permit[uid]:
+                bt.logging.warning(
+                    f"Blacklisting a request from non-validator hotkey {synapse.dendrite.hotkey}"
+                )
+                return True, "Non-validator hotkey"
+
+            
 
         bt.logging.trace(
             f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"


### PR DESCRIPTION
following flags are supported on miner side
- `blacklist.allow_non_registered`: allow requests from non-recognized entities
- `blacklist.force_validator_permit`: blacklist requests from non-validator hotkeys