### PR TITLE
Fix wrong log msg for set_weights

### DIFF
--- a/template/base/validator.py
+++ b/template/base/validator.py
@@ -259,7 +259,7 @@ class BaseValidatorNeuron(BaseNeuron):
         bt.logging.debug("uint_uids", uint_uids)
 
         # Set the weights on chain via our subtensor connection.
-        result = self.subtensor.set_weights(
+        result, msg = self.subtensor.set_weights(
             wallet=self.wallet,
             netuid=self.config.netuid,
             uids=uint_uids,
@@ -271,7 +271,7 @@ class BaseValidatorNeuron(BaseNeuron):
         if result is True:
             bt.logging.info("set_weights on chain successfully!")
         else:
-            bt.logging.error("set_weights failed")
+            bt.logging.error("set_weights failed", msg)
 
     def resync_metagraph(self):
         """Resyncs the metagraph and updates the hotkeys and moving averages based on the new metagraph."""


### PR DESCRIPTION
This pull request fixes the bug where the validator outputs "set_weights failed" wrongfully even though the set_weights was successful. This is due to the fact that `subtensor.set_weights` return a tuple of `(success, message)` but in the code only the message is parsed and used as measure of success on writing weights. 
![image](https://github.com/opentensor/bittensor-subnet-template/assets/3833065/294be402-ad08-48dd-85e9-5f932d4c6fc0)
