### PR TITLE
add loguru to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 bittensor
 torch
+loguru


### PR DESCRIPTION
import is here: [bittensor-subnet-template/template/utils/config.py](https://github.com/opentensor/bittensor-subnet-template/blob/332a4177b6ad85fcf421600758618d9bc4a8b207/template/utils/config.py#L23)

but the loguru package is not installed in the requirements.txt