### PR TITLE
Update: Remove pytorch & replace it with numpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #.idea/
 
 testing/
+
+# Editors
+.vscode/settings.json

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -94,6 +94,11 @@ class Miner(BaseMinerNeuron):
 
         Otherwise, allow the request to be processed further.
         """
+
+        if synapse.dendrite is None or synapse.dendrite.hotkey is None:
+            bt.logging.warning("Received a request without a dendrite or hotkey.")
+            return True, "Missing dendrite or hotkey"
+
         # TODO(developer): Define how miners should blacklist requests.
         uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
         if (
@@ -139,15 +144,19 @@ class Miner(BaseMinerNeuron):
         Example priority logic:
         - A higher stake results in a higher priority value.
         """
+        if synapse.dendrite is None or synapse.dendrite.hotkey is None:
+            bt.logging.warning("Received a request without a dendrite or hotkey.")
+            return 0.0
+        
         # TODO(developer): Define how miners should prioritize requests.
         caller_uid = self.metagraph.hotkeys.index(
             synapse.dendrite.hotkey
         )  # Get the caller index.
-        prirority = float(
+        priority = float(
             self.metagraph.S[caller_uid]
         )  # Return the stake as the priority.
         bt.logging.trace(
-            f"Prioritizing {synapse.dendrite.hotkey} with value: ", prirority
+            f"Prioritizing {synapse.dendrite.hotkey} with value: {priority}"
         )
         return prirority
 
@@ -156,5 +165,5 @@ class Miner(BaseMinerNeuron):
 if __name__ == "__main__":
     with Miner() as miner:
         while True:
-            bt.logging.info("Miner running...", time.time())
+            bt.logging.info(f"Miner running... {time.time()}")
             time.sleep(5)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -65,5 +65,5 @@ class Validator(BaseValidatorNeuron):
 if __name__ == "__main__":
     with Validator() as validator:
         while True:
-            bt.logging.info("Validator running...", time.time())
+            bt.logging.info(f"Validator running... {time.time()}")
             time.sleep(5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 bittensor
-torch

--- a/template/api/examples/subnet21.py
+++ b/template/api/examples/subnet21.py
@@ -17,7 +17,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import torch
 import base64
 import bittensor as bt
 from abc import ABC, abstractmethod

--- a/template/api/get_query_axons.py
+++ b/template/api/get_query_axons.py
@@ -16,8 +16,7 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-
-import torch
+import numpy as np
 import random
 import bittensor as bt
 
@@ -59,10 +58,9 @@ async def ping_uids(dendrite, metagraph, uids, timeout=3):
         bt.logging.error(f"Dendrite ping failed: {e}")
         successful_uids = []
         failed_uids = uids
-    bt.logging.debug("ping() successful uids:", successful_uids)
-    bt.logging.debug("ping() failed uids    :", failed_uids)
+    bt.logging.debug(f"ping() successful uids: {successful_uids}")
+    bt.logging.debug(f"ping() failed uids    : {failed_uids}")
     return successful_uids, failed_uids
-
 
 async def get_query_api_nodes(dendrite, metagraph, n=0.1, timeout=3):
     """
@@ -85,11 +83,10 @@ async def get_query_api_nodes(dendrite, metagraph, n=0.1, timeout=3):
         for uid in metagraph.uids
         if metagraph.validator_trust[uid] > 0
     ]
-    top_uids = torch.where(metagraph.S > torch.quantile(metagraph.S, 1 - n))
-    top_uids = top_uids[0].tolist()
+    top_uids = np.where(metagraph.S > np.quantile(metagraph.S, 1 - n))[0].tolist()
     init_query_uids = set(top_uids).intersection(set(vtrust_uids))
     query_uids, _ = await ping_uids(
-        dendrite, metagraph, init_query_uids, timeout=timeout
+        dendrite, metagraph, list(init_query_uids), timeout=timeout
     )
     bt.logging.debug(
         f"Available API node UIDs for subnet {metagraph.netuid}: {query_uids}"

--- a/template/base/miner.py
+++ b/template/base/miner.py
@@ -16,7 +16,6 @@
 # DEALINGS IN THE SOFTWARE.
 
 import time
-import torch
 import asyncio
 import threading
 import argparse
@@ -27,6 +26,7 @@ import bittensor as bt
 from template.base.neuron import BaseNeuron
 from template.utils.config import add_miner_args
 
+from typing import Union
 
 class BaseMinerNeuron(BaseNeuron):
     """
@@ -52,9 +52,8 @@ class BaseMinerNeuron(BaseNeuron):
             bt.logging.warning(
                 "You are allowing non-registered entities to send requests to your miner. This is a security risk."
             )
-
         # The axon handles request processing, allowing validators to send this miner requests.
-        self.axon = bt.axon(wallet=self.wallet, config=self.config)
+        self.axon = bt.axon(wallet=self.wallet, config=self.config() if callable(self.config) else self.config)
 
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to miner axon.")
@@ -68,7 +67,7 @@ class BaseMinerNeuron(BaseNeuron):
         # Instantiate runners
         self.should_exit: bool = False
         self.is_running: bool = False
-        self.thread: threading.Thread = None
+        self.thread: Union[threading.Thread, None] = None
         self.lock = asyncio.Lock()
 
     def run(self):
@@ -157,7 +156,8 @@ class BaseMinerNeuron(BaseNeuron):
         if self.is_running:
             bt.logging.debug("Stopping miner in background thread.")
             self.should_exit = True
-            self.thread.join(5)
+            if self.thread is not None:
+                self.thread.join(5)
             self.is_running = False
             bt.logging.debug("Stopped")
 

--- a/template/base/utils/weight_utils.py
+++ b/template/base/utils/weight_utils.py
@@ -1,0 +1,189 @@
+import numpy as np
+from typing import Tuple, List
+import bittensor
+
+U32_MAX = 4294967295
+U16_MAX = 65535
+
+def normalize_max_weight(
+    x: np.ndarray, limit: float = 0.1
+) -> np.ndarray:
+    r"""Normalizes the numpy array x so that sum(x) = 1 and the max value is not greater than the limit.
+    Args:
+        x (:obj:`np.ndarray`):
+            Array to be max_value normalized.
+        limit: float:
+            Max value after normalization.
+    Returns:
+        y (:obj:`np.ndarray`):
+            Normalized x array.
+    """
+    epsilon = 1e-7  # For numerical stability after normalization
+
+    weights = x.copy()
+    values = np.sort(weights)
+
+    if x.sum() == 0 or len(x) * limit <= 1:
+        return np.ones_like(x) / x.size
+    else:
+        estimation = values / values.sum()
+
+        if estimation.max() <= limit:
+            return weights / weights.sum()
+
+        # Find the cumulative sum and sorted array
+        cumsum = np.cumsum(estimation, 0)
+
+        # Determine the index of cutoff
+        estimation_sum = np.array(
+            [(len(values) - i - 1) * estimation[i] for i in range(len(values))]
+        )
+        n_values = (estimation / (estimation_sum + cumsum + epsilon) < limit).sum()
+
+        # Determine the cutoff based on the index
+        cutoff_scale = (limit * cumsum[n_values - 1] - epsilon) / (
+            1 - (limit * (len(estimation) - n_values))
+        )
+        cutoff = cutoff_scale * values.sum()
+
+        # Applying the cutoff
+        weights[weights > cutoff] = cutoff
+
+        y = weights / weights.sum()
+
+        return y
+
+
+def convert_weights_and_uids_for_emit(
+    uids: np.ndarray, weights: np.ndarray
+) -> Tuple[List[int], List[int]]:
+    r"""Converts weights into integer u32 representation that sum to MAX_INT_WEIGHT.
+    Args:
+        uids (:obj:`np.ndarray,`):
+            Array of uids as destinations for passed weights.
+        weights (:obj:`np.ndarray,`):
+            Array of weights.
+    Returns:
+        weight_uids (List[int]):
+            Uids as a list.
+        weight_vals (List[int]):
+            Weights as a list.
+    """
+    # Checks.
+    weights = weights.tolist()
+    uids = uids.tolist()
+    if np.min(weights) < 0:
+        raise ValueError(
+            "Passed weight is negative cannot exist on chain {}".format(weights)
+        )
+    if np.min(uids) < 0:
+        raise ValueError("Passed uid is negative cannot exist on chain {}".format(uids))
+    if len(uids) != len(weights):
+        raise ValueError(
+            "Passed weights and uids must have the same length, got {} and {}".format(
+                len(uids), len(weights)
+            )
+        )
+    if np.sum(weights) == 0:
+        return [], []  # Nothing to set on chain.
+    else:
+        max_weight = float(np.max(weights))
+        weights = [
+            float(value) / max_weight for value in weights
+        ]  # max-upscale values (max_weight = 1).
+
+    weight_vals = []
+    weight_uids = []
+    for i, (weight_i, uid_i) in enumerate(list(zip(weights, uids))):
+        uint16_val = round(
+            float(weight_i) * int(U16_MAX)
+        )  # convert to int representation.
+
+        # Filter zeros
+        if uint16_val != 0:  # Filter zeros
+            weight_vals.append(uint16_val)
+            weight_uids.append(uid_i)
+
+    return weight_uids, weight_vals
+
+
+def process_weights_for_netuid(
+    uids,
+    weights: np.ndarray,
+    netuid: int,
+    subtensor: "bittensor.subtensor",
+    metagraph: "bittensor.metagraph" = None,
+    exclude_quantile: int = 0,
+) -> np.ndarray:
+    bittensor.logging.debug("process_weights_for_netuid()")
+    bittensor.logging.debug("weights", weights)
+    bittensor.logging.debug("netuid", netuid)
+    bittensor.logging.debug("subtensor", subtensor)
+    bittensor.logging.debug("metagraph", metagraph)
+
+    # Get latest metagraph from chain if metagraph is None.
+    if metagraph == None:
+        metagraph = subtensor.metagraph(netuid)
+
+    # Cast weights to floats.
+    if not isinstance(weights, np.ndarray) or weights.dtype != np.float32:
+        weights = weights.astype(np.float32)
+
+    # Network configuration parameters from an subtensor.
+    # These parameters determine the range of acceptable weights for each neuron.
+    quantile = exclude_quantile / U16_MAX
+    min_allowed_weights = subtensor.min_allowed_weights(netuid=netuid)
+    max_weight_limit = subtensor.max_weight_limit(netuid=netuid)
+    bittensor.logging.debug("quantile", quantile)
+    bittensor.logging.debug("min_allowed_weights", min_allowed_weights)
+    bittensor.logging.debug("max_weight_limit", max_weight_limit)
+
+    # Find all non zero weights.
+    non_zero_weight_idx = np.argwhere(weights > 0).squeeze()
+    non_zero_weight_uids = uids[non_zero_weight_idx]
+    non_zero_weights = weights[non_zero_weight_idx]
+    if non_zero_weights.size == 0 or metagraph.n < min_allowed_weights:
+        bittensor.logging.warning("No non-zero weights returning all ones.")
+        final_weights = np.ones((metagraph.n)) / metagraph.n
+        bittensor.logging.debug("final_weights", final_weights)
+        return np.arange(len(final_weights)), final_weights
+
+    elif non_zero_weights.size < min_allowed_weights:
+        bittensor.logging.warning(
+            "No non-zero weights less then min allowed weight, returning all ones."
+        )
+        weights = (
+            np.ones((metagraph.n)) * 1e-5
+        )  # creating minimum even non-zero weights
+        weights[non_zero_weight_idx] += non_zero_weights
+        bittensor.logging.debug("final_weights", weights)
+        normalized_weights = normalize_max_weight(
+            x=weights, limit=max_weight_limit
+        )
+        return np.arange(len(normalized_weights)), normalized_weights
+
+    bittensor.logging.debug("non_zero_weights", non_zero_weights)
+
+    # Compute the exclude quantile and find the weights in the lowest quantile
+    max_exclude = max(0, len(non_zero_weights) - min_allowed_weights) / len(
+        non_zero_weights
+    )
+    exclude_quantile = min([quantile, max_exclude])
+    lowest_quantile = np.quantile(non_zero_weights, exclude_quantile)
+    bittensor.logging.debug("max_exclude", max_exclude)
+    bittensor.logging.debug("exclude_quantile", exclude_quantile)
+    bittensor.logging.debug("lowest_quantile", lowest_quantile)
+
+    # Exclude all weights below the allowed quantile.
+    non_zero_weight_uids = non_zero_weight_uids[lowest_quantile <= non_zero_weights]
+    non_zero_weights = non_zero_weights[lowest_quantile <= non_zero_weights]
+    bittensor.logging.debug("non_zero_weight_uids", non_zero_weight_uids)
+    bittensor.logging.debug("non_zero_weights", non_zero_weights)
+
+    # Normalize weights and return.
+    normalized_weights = normalize_max_weight(
+        x=non_zero_weights, limit=max_weight_limit
+    )
+    bittensor.logging.debug("final_weights", normalized_weights)
+
+    return non_zero_weight_uids, normalized_weights

--- a/template/base/validator.py
+++ b/template/base/validator.py
@@ -19,16 +19,17 @@
 
 
 import copy
-import torch
+import numpy as np
 import asyncio
 import argparse
 import threading
 import bittensor as bt
 
-from typing import List
+from typing import List, Union
 from traceback import print_exception
 
 from template.base.neuron import BaseNeuron
+from template.base.utils.weight_utils import process_weights_for_netuid, convert_weights_and_uids_for_emit #TODO: Replace when bittensor switches to numpy
 from template.mock import MockDendrite
 from template.utils.config import add_validator_args
 
@@ -60,8 +61,8 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Set up initial scoring weights for validation
         bt.logging.info("Building validation weights.")
-        self.scores = torch.zeros(
-            self.metagraph.n, dtype=torch.float32, device=self.device
+        self.scores = np.zeros(
+            self.metagraph.n, dtype=np.float32
         )
 
         # Init sync with the network. Updates the metagraph.
@@ -79,7 +80,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # Instantiate runners
         self.should_exit: bool = False
         self.is_running: bool = False
-        self.thread: threading.Thread = None
+        self.thread: Union[threading.Thread, None] = None
         self.lock = asyncio.Lock()
 
     def serve_axon(self):
@@ -164,9 +165,9 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # In case of unforeseen errors, the validator will log the error and continue operations.
         except Exception as err:
-            bt.logging.error("Error during validation", str(err))
+            bt.logging.error(f"Error during validation: {str(err)}")
             bt.logging.debug(
-                print_exception(type(err), err, err.__traceback__)
+                str(print_exception(type(err), err, err.__traceback__))
             )
 
     def run_in_background_thread(self):
@@ -223,24 +224,24 @@ class BaseValidatorNeuron(BaseNeuron):
         """
 
         # Check if self.scores contains any NaN values and log a warning if it does.
-        if torch.isnan(self.scores).any():
+        if np.isnan(self.scores).any():
             bt.logging.warning(
                 f"Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward functions."
             )
 
         # Calculate the average reward for each uid across non-zero values.
         # Replace any NaN values with 0.
-        raw_weights = torch.nn.functional.normalize(self.scores, p=1, dim=0)
+        raw_weights = self.scores / np.linalg.norm(self.scores, ord=1, axis=0, keepdims=True)
 
         bt.logging.debug("raw_weights", raw_weights)
-        bt.logging.debug("raw_weight_uids", self.metagraph.uids.to("cpu"))
+        bt.logging.debug("raw_weight_uids", str(self.metagraph.uids.tolist()))
         # Process the raw weights to final_weights via subtensor limitations.
         (
             processed_weight_uids,
             processed_weights,
-        ) = bt.utils.weight_utils.process_weights_for_netuid(
-            uids=self.metagraph.uids.to("cpu"),
-            weights=raw_weights.to("cpu"),
+        ) = process_weights_for_netuid(
+            uids=self.metagraph.uids,
+            weights=raw_weights,
             netuid=self.config.netuid,
             subtensor=self.subtensor,
             metagraph=self.metagraph,
@@ -252,7 +253,7 @@ class BaseValidatorNeuron(BaseNeuron):
         (
             uint_uids,
             uint_weights,
-        ) = bt.utils.weight_utils.convert_weights_and_uids_for_emit(
+        ) = convert_weights_and_uids_for_emit(
             uids=processed_weight_uids, weights=processed_weights
         )
         bt.logging.debug("uint_weights", uint_weights)
@@ -299,9 +300,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # If so, we need to add new hotkeys and moving averages.
         if len(self.hotkeys) < len(self.metagraph.hotkeys):
             # Update the size of the moving average scores.
-            new_moving_average = torch.zeros((self.metagraph.n)).to(
-                self.device
-            )
+            new_moving_average = np.zeros((self.metagraph.n))
             min_len = min(len(self.hotkeys), len(self.scores))
             new_moving_average[:min_len] = self.scores[:min_len]
             self.scores = new_moving_average
@@ -309,34 +308,32 @@ class BaseValidatorNeuron(BaseNeuron):
         # Update the hotkeys.
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
 
-    def update_scores(self, rewards: torch.FloatTensor, uids: List[int]):
+    def update_scores(self, rewards: np.ndarray, uids: List[int]):
         """Performs exponential moving average on the scores based on the rewards received from the miners."""
 
         # Check if rewards contains NaN values.
-        if torch.isnan(rewards).any():
+        if np.isnan(rewards).any():
             bt.logging.warning(f"NaN values detected in rewards: {rewards}")
             # Replace any NaN values in rewards with 0.
-            rewards = torch.nan_to_num(rewards, 0)
-
-        # Check if `uids` is already a tensor and clone it to avoid the warning.
-        if isinstance(uids, torch.Tensor):
-            uids_tensor = uids.clone().detach()
+            rewards = np.nan_to_num(rewards, nan=0)
+        # Check if `uids` is already a numpy array and copy it to avoid the warning.
+        if isinstance(uids, np.ndarray):
+            uids_array = uids.copy()
         else:
-            uids_tensor = torch.tensor(uids).to(self.device)
+            uids_array = np.array(uids)
 
         # Compute forward pass rewards, assumes uids are mutually exclusive.
         # shape: [ metagraph.n ]
-        scattered_rewards: torch.FloatTensor = self.scores.scatter(
-            0, uids_tensor, rewards
-        ).to(self.device)
+        scattered_rewards: np.ndarray = np.zeros_like(self.scores)
+        scattered_rewards[uids_array] = rewards
         bt.logging.debug(f"Scattered rewards: {rewards}")
 
         # Update scores with rewards produced by this step.
         # shape: [ metagraph.n ]
         alpha: float = self.config.neuron.moving_average_alpha
-        self.scores: torch.FloatTensor = alpha * scattered_rewards + (
+        self.scores: np.ndarray = alpha * scattered_rewards + (
             1 - alpha
-        ) * self.scores.to(self.device)
+        ) * self.scores
         bt.logging.debug(f"Updated moving avg scores: {self.scores}")
 
     def save_state(self):
@@ -344,13 +341,11 @@ class BaseValidatorNeuron(BaseNeuron):
         bt.logging.info("Saving validator state.")
 
         # Save the state of the validator to file.
-        torch.save(
-            {
-                "step": self.step,
-                "scores": self.scores,
-                "hotkeys": self.hotkeys,
-            },
-            self.config.neuron.full_path + "/state.pt",
+        np.savez(
+            self.config.neuron.full_path + "/state.npz",
+            step=self.step,
+            scores=self.scores,
+            hotkeys=self.hotkeys,
         )
 
     def load_state(self):
@@ -358,7 +353,7 @@ class BaseValidatorNeuron(BaseNeuron):
         bt.logging.info("Loading validator state.")
 
         # Load the state of the validator from file.
-        state = torch.load(self.config.neuron.full_path + "/state.pt")
+        state = np.load(self.config.neuron.full_path + "/state.npz")
         self.step = state["step"]
         self.scores = state["scores"]
         self.hotkeys = state["hotkeys"]

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -17,11 +17,25 @@
 # DEALINGS IN THE SOFTWARE.
 
 import os
-import torch
+import subprocess
 import argparse
 import bittensor as bt
 from loguru import logger
 
+def is_cuda_available():
+    try:
+        output = subprocess.check_output(["nvidia-smi", "-L"], stderr=subprocess.STDOUT)
+        if "NVIDIA" in output.decode("utf-8"):
+            return "cuda"
+    except Exception:
+        pass
+    try:
+        output = subprocess.check_output(["nvcc", "--version"]).decode("utf-8")
+        if "release" in output:
+            return "cuda"
+    except Exception:
+        pass
+    return "cpu"
 
 def check_config(cls, config: "bt.Config"):
     r"""Checks/validates the config namespace object."""
@@ -67,7 +81,7 @@ def add_args(cls, parser):
         "--neuron.device",
         type=str,
         help="Device to run on.",
-        default="cuda" if torch.cuda.is_available() else "cpu",
+        default=is_cuda_available(),
     )
 
     parser.add_argument(

--- a/template/utils/uids.py
+++ b/template/utils/uids.py
@@ -1,6 +1,6 @@
-import torch
 import random
 import bittensor as bt
+import numpy as np
 from typing import List
 
 
@@ -28,13 +28,13 @@ def check_uid_availability(
 
 def get_random_uids(
     self, k: int, exclude: List[int] = None
-) -> torch.LongTensor:
+) -> np.ndarray:
     """Returns k available random uids from the metagraph.
     Args:
         k (int): Number of uids to return.
         exclude (List[int]): List of uids to exclude from the random sampling.
     Returns:
-        uids (torch.LongTensor): Randomly sampled available uids.
+        uids (np.ndarray): Randomly sampled available uids.
     Notes:
         If `k` is larger than the number of available `uids`, set `k` to the number of available `uids`.
     """
@@ -60,5 +60,5 @@ def get_random_uids(
             [uid for uid in avail_uids if uid not in candidate_uids],
             k - len(candidate_uids),
         )
-    uids = torch.tensor(random.sample(available_uids, k))
+    uids = np.array(random.sample(available_uids, k))
     return uids

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -16,8 +16,7 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-
-import torch
+import numpy as np
 from typing import List
 
 
@@ -37,18 +36,22 @@ def get_rewards(
     self,
     query: int,
     responses: List[float],
-) -> torch.FloatTensor:
+) -> np.ndarray:
     """
-    Returns a tensor of rewards for the given query and responses.
+    Returns an array of rewards for the given query and responses.
 
     Args:
     - query (int): The query sent to the miner.
     - responses (List[float]): A list of responses from the miner.
 
     Returns:
-    - torch.FloatTensor: A tensor of rewards for the given query and responses.
+    - np.ndarray: An array of rewards for the given query and responses.
     """
     # Get all the reward results by iteratively calling your reward() function.
-    return torch.FloatTensor(
-        [reward(query, response) for response in responses]
-    ).to(self.device)
+    # Cast response to int as the reward function expects an int type for response.
+    
+    # Remove any None values
+    responses = [response for response in responses if response is not None]
+    return np.array(
+        [reward(query, int(response)) for response in responses]
+    )


### PR DESCRIPTION
## Description
Replace torch with numpy in the subnet template.

## Related Issue(s) / PRs
Bittensor: https://github.com/opentensor/bittensor/pull/1786

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

N/A

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A

## Additional Notes
Though the code removes the need for torch installation specially for the subnet template, the user will still need to install torch for the core bittensor module. However, once the above mentioned PR is pulled in, some functionality — namely template/base/utils — can be offloaded to the core module (A TODO for the same is available at template/base/utils/weight_utils.py).