### PR TITLE
Update doc on registering keys 

### DIFF
--- a/docs/running_on_testnet.md
+++ b/docs/running_on_testnet.md
@@ -129,7 +129,7 @@ This step registers your subnet validator and subnet miner keys to the subnet, g
 Register your miner key to the subnet:
 
 ```bash
-btcli subnet recycle_register --netuid 13 --subtensor.network test --wallet.name miner --wallet.hotkey default
+btcli subnet register --netuid 13 --subtensor.network test --wallet.name miner --wallet.hotkey default
 ```
 
 Follow the below prompts:
@@ -146,7 +146,7 @@ Follow the below prompts:
 Next, register your validator key to the subnet:
 
 ```bash
-btcli subnet recycle_register --netuid 13 --subtensor.network test --wallet.name validator --wallet.hotkey default
+btcli subnet register --netuid 13 --subtensor.network test --wallet.name validator --wallet.hotkey default
 ```
 
 Follow the prompts:


### PR DESCRIPTION
The `cycle_register` seems to have been replaced by register but the docs never got updated.