### PR TITLE
Remove abusable code from subnet template

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -125,7 +125,7 @@ class Miner(BaseMinerNeuron):
             return False, "Hotkey recognized!"
         except Exception as e:
             bt.logging.error(f"Exception in blacklist_fn: {str(e)}")
-            return True
+            return True, "Blacklist error"
 
     async def priority(self, synapse: template.protocol.Dummy) -> float:
         """

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -119,7 +119,7 @@ class Miner(BaseMinerNeuron):
                     )
                     return True, "Non-validator hotkey"
 
-            stake = self.metagraph.S[requesting_uid].item()
+            stake = self.metagraph.S[uid].item()
 
             # ignore minimal weight validators that should not be directly contacting a miner's synpase due to the lack of weight setting capability.
             if stake < self.config.blacklist.minimum_stake:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -94,6 +94,7 @@ class Miner(BaseMinerNeuron):
 
         Otherwise, allow the request to be processed further.
         """
+        # TODO (developer): Define how miners should blacklist requests.
         try:
             # check for missing hotkey malformed request to avoid throwing ValueError on metagraph.hotkeys.index (unhandled exception)
             if not synapse.dendrite.hotkey:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -109,7 +109,6 @@ class Miner(BaseMinerNeuron):
                 )
                 return True, "Unrecognized hotkey"
 
-            # synapse.dendrite.hotkey can cause a ValueError if not check for not None
             uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
             
             if self.config.blacklist.force_validator_permit:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -122,7 +122,8 @@ class Miner(BaseMinerNeuron):
                 f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
             )
             return False, "Hotkey recognized!"
-        except:
+        except Exception as e:
+            bt.logging.error(f"Exception in blacklist_fn: {str(e)}")
             return True
 
     async def priority(self, synapse: template.protocol.Dummy) -> float:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -123,7 +123,7 @@ class Miner(BaseMinerNeuron):
             stake = self.metagraph.S[requesting_uid].item()
 
             # ignore minimal weight validators that should not be directly contacting a miner's synpase due to the lack of weight setting capability.
-            if stake < 1024:
+            if stake < self.config.blacklist.minimum_stake:
                 return True, "Minimal stake validator"
     
             bt.logging.trace(

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -59,7 +59,7 @@ class Miner(BaseMinerNeuron):
         the miner's intended operation. This method demonstrates a basic transformation of input data.
         """
         # TODO(developer): Replace with actual implementation logic.
-        synapse.dummy_output = synapse.dummy_input * 2
+        # synapse.dummy_output = synapse.dummy_input * 2
         return synapse
 
     async def blacklist(
@@ -94,30 +94,36 @@ class Miner(BaseMinerNeuron):
 
         Otherwise, allow the request to be processed further.
         """
-        # TODO(developer): Define how miners should blacklist requests.
-        uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
-        if (
-            not self.config.blacklist.allow_non_registered
-            and synapse.dendrite.hotkey not in self.metagraph.hotkeys
-        ):
-            # Ignore requests from un-registered entities.
-            bt.logging.trace(
-                f"Blacklisting un-registered hotkey {synapse.dendrite.hotkey}"
-            )
-            return True, "Unrecognized hotkey"
-
-        if self.config.blacklist.force_validator_permit:
-            # If the config is set to force validator permit, then we should only allow requests from validators.
-            if not self.metagraph.validator_permit[uid]:
-                bt.logging.warning(
-                    f"Blacklisting a request from non-validator hotkey {synapse.dendrite.hotkey}"
+        try: 
+            # TODO(developer): Define how miners should blacklist requests.
+            if not synapse.dendrite.hotkey:
+                return True, "Missing hotkey/Malformed request"
+                
+            uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+            if (
+                not self.config.blacklist.allow_non_registered
+                and synapse.dendrite.hotkey not in self.metagraph.hotkeys
+            ):
+                # Ignore requests from un-registered entities.
+                bt.logging.trace(
+                    f"Blacklisting un-registered hotkey {synapse.dendrite.hotkey}"
                 )
-                return True, "Non-validator hotkey"
-
-        bt.logging.trace(
-            f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
-        )
-        return False, "Hotkey recognized!"
+                return True, "Unrecognized hotkey"
+    
+            if self.config.blacklist.force_validator_permit:
+                # If the config is set to force validator permit, then we should only allow requests from validators.
+                if not self.metagraph.validator_permit[uid]:
+                    bt.logging.warning(
+                        f"Blacklisting a request from non-validator hotkey {synapse.dendrite.hotkey}"
+                    )
+                    return True, "Non-validator hotkey"
+    
+            bt.logging.trace(
+                f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
+            )
+            return False, "Hotkey recognized!"
+        except:
+            return True
 
     async def priority(self, synapse: template.protocol.Dummy) -> float:
         """

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -99,7 +99,6 @@ class Miner(BaseMinerNeuron):
             if not synapse.dendrite.hotkey:
                 return True, "Missing hotkey/Malformed request"
                 
-            uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
             if (
                 not self.config.blacklist.allow_non_registered
                 and synapse.dendrite.hotkey not in self.metagraph.hotkeys
@@ -109,7 +108,9 @@ class Miner(BaseMinerNeuron):
                     f"Blacklisting un-registered hotkey {synapse.dendrite.hotkey}"
                 )
                 return True, "Unrecognized hotkey"
-    
+                
+            uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+            
             if self.config.blacklist.force_validator_permit:
                 # If the config is set to force validator permit, then we should only allow requests from validators.
                 if not self.metagraph.validator_permit[uid]:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -59,7 +59,7 @@ class Miner(BaseMinerNeuron):
         the miner's intended operation. This method demonstrates a basic transformation of input data.
         """
         # TODO(developer): Replace with actual implementation logic.
-        # synapse.dummy_output = synapse.dummy_input * 2
+        synapse.dummy_output = synapse.dummy_input * 2
         return synapse
 
     async def blacklist(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -145,6 +145,13 @@ def add_miner_args(cls, parser):
     )
 
     parser.add_argument(
+        "--blacklist.minimum_stake",
+        type=int,
+        help="If set, we will force incoming requests to have a weight settable stake.",
+        default=1024,
+    )
+
+    parser.add_argument(
         "--wandb.project_name",
         type=str,
         default="template-miners",


### PR DESCRIPTION
The default subnet code has been reused on major mainnet subnets leading to predictable issues with lack of checks towards stakeless validators, and a triggerable exception with a longer stacktrace that a normal blacklistexception.

Forcing an error in the blacklist_fn leads to an amplication of the normal blacklist response. For instance, a normal blacklist repsonse will state the short reason, i.e. not registered. The error blacklist response will include the full error message. Some error messages may be longer than others (and the ValueError one is), leading to an amplication in the normal response. The effect amplification is around 2-3x depending on the original return text of the blacklist_fn. 

Utilizing these flaws, attackers were able to do two things:

**Subnet 2 (missing stake check)**

On subnet 2, a validators minimum stake was not being checked. As a result, a malicious miner was able to register a low stake validator, and prompt users with challenges. The purpose of these challenges was to slow miners average response time in comparison to their normal response time to a real validator. In addition, the attacker employed several sneaky methods such as monitoring other validator requests, in order to sync their request to a validators, forcing a concurrent request on the innocent miner.

As a result, I believe it is best practice to leave in a default stake blacklist as an example, and allow subnet devs to REMOVE this if they wish, not the other way around. In best practice, the safest solution should be offered as the example, not a barebones solution. If the goal was for subnet devs to inspect the blacklist function and tailor it to their use-case, this has been demonstrated to not happen on at least 6 subnets (likely more). In most subnets, a stakeless validator has no actual purpose of calling a miners synapse. In practice, this lack of a default example has been shown to cause issues in various subnets that are often not picked up on right away.

**Subnet 31 (triggerable unhandled exception)**

Other affected subnets with a similar issue to 31 included subnet 33, 28, 25, 16, 11, 5. Here's my leading theory on why this leads to exhaustion, rather than the normal blacklist behavior, which as @mjurbanski-reef has shown, already throws an exception normally. Let's compare both scenarios, specifically taking a look at the traceback that will be printed here:

https://github.com/opentensor/bittensor/blob/master/bittensor/axon.py#L959

Unhandled exception in blacklist_fn:

blacklist_fn -> blacklist -> dispatch

Normal handled exception stacktrace:

blacklist -> dispatch

As you can see, forcing an error in the blacklist_fn in the subnet (note not the blacklist fn in axon.py) leads to a larger stacktrace. This stacktrace would cost additional resources to gather and print, and would even possibly include stack trace information from the asyncio upstream, metagraph calls, etc. The stacktrace length should be roughly 3-5x the size due to the increased callstack.

While a normal exception thrown by blacklist with normal behavior (i.e. the person is blacklisted) leads to a much shorter stacktrace, only blacklist, then caught by dispatch.

It's my belief this is part one to why this leads to exhaustion. The second part, is the increased response size when throwing an error from the blacklist_fn. A combination of both means greater CPU/mem pressure, and greater networking pressure. When hundreds to thousands of requests are coming in, small inefficiencies like these can play a big part to exhausting your miner. From testing, removing the unhandled exception from blacklist_fn led to continued operation for the miner while being attacked, while not handling the exception and letting it pass downstream caused server reboots on various miners machines, and overall total DoS to the axon. Why this would happen? I can only guess differences in stacktrace/callstack length.