### PR TITLE
Fix process_weights_for_netuid edge case

### DIFF
--- a/template/base/utils/weight_utils.py
+++ b/template/base/utils/weight_utils.py
@@ -140,6 +140,9 @@ def process_weights_for_netuid(
 
     # Find all non zero weights.
     non_zero_weight_idx = np.argwhere(weights > 0).squeeze()
+    if non_zero_weight_idx.ndim == 0:
+        non_zero_weight_idx = non_zero_weight_idx.reshape((1,))
+
     non_zero_weight_uids = uids[non_zero_weight_idx]
     non_zero_weights = weights[non_zero_weight_idx]
     if non_zero_weights.size == 0 or metagraph.n < min_allowed_weights:


### PR DESCRIPTION
This is a bugfix for #93

The edge case occurs when there is only a single non-zero weight to be processed, which results in `len` being called on an array scalar. The fix is to reshape said array scaler to make it a sized object. 