### PR TITLE
Update link to text prompting repo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This starter template is split into three primary files. To write your own incen
 
 ### Example
 
-The Bittensor Subnet 1 for Text Prompting is built using this template. See [Bittensor Text-Prompting](https://github.com/opentensor/text-prompting) for how to configure the files and how to add monitoring and telemetry and support multiple miner types. Also see this Subnet 1 in action on [Taostats](https://taostats.io/subnets/netuid-1/) explorer.
+The Bittensor Subnet 1 for Text Prompting is built using this template. See [prompting](https://github.com/macrocosm-os/prompting) for how to configure the files and how to add monitoring and telemetry and support multiple miner types. Also see this Subnet 1 in action on [Taostats](https://taostats.io/subnets/netuid-1/) explorer.
 
 ---
 


### PR DESCRIPTION
The introduction has an example to "Bittensor Text-Prompting" 

![example_with_link](https://github.com/opentensor/bittensor-subnet-template/assets/16657983/734fe571-f475-4d3e-bb03-ef03b2635d3a)

which links to a [deprecated repo](https://github.com/opentensor/text-prompting)

![deprecated](https://github.com/opentensor/bittensor-subnet-template/assets/16657983/8ea8b45a-24fe-4deb-8edd-ef87ed1b37f0)

should we be using this repo instead?

https://github.com/macrocosm-os/prompting

![macrocosmos](https://github.com/opentensor/bittensor-subnet-template/assets/16657983/782a6e58-afd4-4331-b520-ce333eb09dbf)
