### PR TITLE
Fix typo in miner.py

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -34,7 +34,7 @@ class Miner(BaseMinerNeuron):
 
     This class inherits from the BaseMinerNeuron class, which in turn inherits from BaseNeuron. The BaseNeuron class takes care of routine tasks such as setting up wallet, subtensor, metagraph, logging directory, parsing config, etc. You can override any of the methods in BaseNeuron if you need to customize the behavior.
 
-    This class provides reasonable default behavior for a miner such as blacklisting unrecognized hotkeys, prioritizing requests based on stake, and forwarding requests to the forward function. If you need to define custom
+    This class provides reasonable default behavior for a miner such as blacklisting unrecognized hotkeys, prioritizing requests based on stake, and forwarding requests to the forward function.
     """
 
     def __init__(self, config=None):


### PR DESCRIPTION
Remove the incomplete sentence "If you need to define custom". The previous sentence already mentions customizing behaviour.