### PR TITLE
Update generate.py - fix case-sensitive variable call

### DIFF
--- a/verify/generate.py
+++ b/verify/generate.py
@@ -7,7 +7,7 @@ import bittensor
 
 
 def main(args):
-    wallet = bittensor.wallet(name=args.name)
+    wallet = bittensor.Wallet(name=args.name)
     keypair = wallet.coldkey
 
     timestamp = datetime.now()


### PR DESCRIPTION
The current version of bittensor references the wallet as "Wallet" (with a capital "W").  generate.py defines wallet as "bittensor.wallet" and thus throws the error "AttributeError: module 'bittensor' has no attribute 'wallet'. Did you mean: 'Wallet'?".  This PR updates the definition to "bittensor.Wallet".