### PR TITLE
docs: correct typo 'recieve' to 'receive' in streaming tutorial

### DIFF
--- a/docs/stream_tutorial/README.md
+++ b/docs/stream_tutorial/README.md
@@ -96,7 +96,7 @@ class MyStreamingSynapse(bt.StreamingSynapse):
         return self.completion
 
     # implement your `process_streaming_response` logic to actually yield objects to the streamer
-    # this effectively defines the async generator that you'll recieve on the client side
+    # this effectively defines the async generator that you'll receive on the client side
     async def process_streaming_response(self, response: MyStreamingSynapse):
         # this is an example of how you might process a streaming response
         # iterate over the response content and yield each line


### PR DESCRIPTION
## Description

This PR fixes a simple typo in the Bittensor subnet template documentation.

**Change:** Line 99 of : Changed 'recieve' to 'receive' in the comment:



## Context

This is the official Bittensor subnet template repository, so fixing this typo will benefit all forks and users who reference this documentation. The typo was in a comment explaining how the  method works in the streaming tutorial.

## Testing

No functional changes - this is purely a documentation fix. The change maintains the exact same functionality while correcting the spelling error.