### PR TITLE
fix: replace `btcli subnet lock_cost` with `btcli subnet burn-cost`

### DIFF
--- a/docs/running_on_testnet.md
+++ b/docs/running_on_testnet.md
@@ -87,13 +87,13 @@ Creating subnets on the testnet is competitive. The cost is determined by the ra
 By default you must have at least 100 testnet TAO in your owner wallet to create a subnet. However, the exact amount will fluctuate based on demand. The below command shows how to get the current price of creating a subnet.
 
 ```bash
-btcli subnet lock_cost --subtensor.network test
+btcli subnet burn-cost --network test
 ```
 
 The above command will show:
 
 ```bash
->> Subnet lock cost: τ100.000000000
+>> Subnet burn cost: τ100.000000000
 ```
 
 ## 4. (Optional) Get faucet tokens


### PR DESCRIPTION
`lock_cost` was removed in btcli v9.0.0 (Rao rewrite), where TAO is burned on subnet registration rather than locked. Updated command to `btcli subnet burn-cost --network test` to reflect current CLI API.