### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!IMPORTANT]
+> **This repository is archived and no longer maintained.**
+>
+> This template targets the legacy Bittensor SDK (v10) and its `Axon`/`Dendrite`/`Synapse` networking stack, which was removed in Bittensor 11. It will not work with current releases.
+>
+> To build a subnet against Bittensor 11, see the [migration guide](https://bittensor.com/docs/migration) and the [signed requests guide](https://bittensor.com/docs/guides/signed-requests) for the replacement identity layer.
+
 <div align="center">
 
 # **Bittensor Subnet Template** <!-- omit in toc -->


### PR DESCRIPTION
## Summary
- Adds an archive/deprecation banner to the README: this template targets the v10 SDK's Axon/Dendrite/Synapse stack, which was removed in Bittensor 11, and points readers at the v11 migration and signed-requests guides.

The repository will be archived once this merges.

Made with [Cursor](https://cursor.com)